### PR TITLE
feat: Add --all flag to cleanup command

### DIFF
--- a/src/cli/cleanup/app/mod.rs
+++ b/src/cli/cleanup/app/mod.rs
@@ -29,10 +29,11 @@ pub enum App {
 impl App {
     pub fn run<B: ratatui::backend::Backend>(
         buildkit: &BuildKitD,
+        all: bool,
         terminal: &mut Terminal<B>,
     ) -> color_eyre::Result<()> {
         // First step
-        let mut app = Self::loading(buildkit.clone());
+        let mut app = Self::loading(buildkit.clone(), all);
         let mut images_for_removal = Vec::new();
         loop {
             // Check for state transitions
@@ -74,7 +75,10 @@ impl App {
         }
     }
 
-    fn loading(buildkit: BuildKitD) -> Self {
+    fn loading(
+        buildkit: BuildKitD,
+        all: bool,
+    ) -> Self {
         let (tx, rx) = std::sync::mpsc::channel();
 
         // Spawn async task to fetch containers for stop
@@ -85,12 +89,16 @@ impl App {
                     let containers = buildkit.list_containers().await?;
                     let images = buildkit.list_images().await?;
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                    // consider only orphan Shell-Cell containers and images
-                    let containers = containers
-                        .into_iter()
-                        .filter(|c| c.orphan)
-                        .collect::<Vec<_>>();
-                    let images = images.into_iter().filter(|c| c.orphan).collect::<Vec<_>>();
+                    let containers = if all {
+                        containers
+                    } else {
+                        containers.into_iter().filter(|c| c.orphan).collect()
+                    };
+                    let images = if all {
+                        images
+                    } else {
+                        images.into_iter().filter(|c| c.orphan).collect()
+                    };
 
                     color_eyre::eyre::Ok((containers, images))
                 };

--- a/src/cli/cleanup/app/ui.rs
+++ b/src/cli/cleanup/app/ui.rs
@@ -65,7 +65,7 @@ fn render_loading(
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            "Fetching 'Shell-Cell' containers for cleaning",
+            "Fetching 'Shell-Cell' containers and images for cleaning",
             Style::default().fg(Color::Gray),
         )),
     ];

--- a/src/cli/cleanup/mod.rs
+++ b/src/cli/cleanup/mod.rs
@@ -3,10 +3,10 @@ mod app;
 use self::app::App;
 use crate::buildkit::BuildKitD;
 
-pub async fn cleanup() -> color_eyre::Result<()> {
+pub async fn cleanup(all: bool) -> color_eyre::Result<()> {
     let buildkit = BuildKitD::start().await?;
     let mut terminal = ratatui::try_init()?;
-    let res = App::run(&buildkit, &mut terminal);
+    let res = App::run(&buildkit, all, &mut terminal);
     ratatui::try_restore()?;
     res
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,7 +51,11 @@ pub enum Commands {
     /// Clean up all orphan Shell-Cell containers with their corresponding images and just
     /// single images (those no longer associated with any existing Shell-Cell
     /// blueprint files).
-    Cleanup,
+    Cleanup {
+        /// Remove ALL Shell-Cell containers and images, not only orphaned ones
+        #[clap(long)]
+        all: bool,
+    },
 }
 
 impl Cli {
@@ -79,7 +83,7 @@ impl Cli {
             Some(Commands::Init { path }) => init::init(path)?,
             Some(Commands::Ls) => ls::ls().await?,
             Some(Commands::Stop) => stop::stop().await?,
-            Some(Commands::Cleanup) => cleanup::cleanup().await?,
+            Some(Commands::Cleanup { all }) => cleanup::cleanup(all).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
# Description

Adds an `--all` flag to the `scell cleanup` command. When provided, it removes **all** Shell-Cell containers and images instead of only orphaned ones.

**Changes:**
- Added `--all` boolean flag to the `Cleanup` CLI command
- Passed the flag through `cleanup()` → `App::run()` → `App::loading()`
- When `--all` is true, skips orphan filtering and includes all Shell-Cell containers and images for removal
- Updated loading UI text to mention both containers and images

**Example:**
```sh
# Current behavior: remove only orphaned containers/images
scell cleanup

# New: remove ALL Shell-Cell containers and images
scell cleanup --all
```

## Related Issue(s) (Optional)

Closes #109