### PR TITLE
feat: Debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,9 +2533,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,7 @@ dependencies = [
  "tokio",
  "tui-scrollview",
  "tui-term",
+ "uuid",
  "yaml_serde",
 ]
 
@@ -3446,9 +3447,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "shell-cell"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "async-channel",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +119,17 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -205,6 +222,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -450,6 +470,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+dependencies = [
+ "async-trait",
+ "convert_case 0.6.0",
+ "json5",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde-untagged",
+ "serde_core",
+ "serde_json",
+ "toml",
+ "winnow",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +499,35 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -537,6 +606,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -632,7 +707,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -679,6 +754,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -734,6 +818,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1033,6 +1128,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1049,6 +1150,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1473,6 +1583,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1917,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2274,6 +2411,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
+dependencies = [
+ "bitflags 2.11.0",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +2623,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2676,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2549,6 +2731,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "config",
  "cue-rs",
  "dirs",
  "dockerfile-parser-rs",
@@ -2945,6 +3128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,6 +3208,37 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3131,6 +3354,12 @@ dependencies = [
  "ratatui-widgets",
  "vt100",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -3830,6 +4059,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3931,6 +4169,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ dockerfile-parser-rs = "3.2.2"
 base64 = "0.22.1"
 tui-scrollview = "0.6.2"
 cue-rs = "0.1.3"
+config = "0.15.22"
 
 [dev-dependencies]
 indoc = "2.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell-cell"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2024"
 description = "Shell-Cell. CLI app to spawn and manage containerized shell environments"
 repository = "https://github.com/Mr-Leshiy/shell-cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ base64 = "0.22.1"
 tui-scrollview = "0.6.2"
 cue-rs = "0.1.3"
 config = "0.15.22"
+uuid = { version = "1.23", features = ["v7"] }
 
 [dev-dependencies]
 indoc = "2.0.7"

--- a/src/cli/cleanup/app/ui.rs
+++ b/src/cli/cleanup/app/ui.rs
@@ -276,7 +276,12 @@ fn render_cleaning_images(
 fn main_block() -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
-        .title("Cleaning 'Shell-Cell' Containers and Images")
+        .title(format!(
+            "Cleaning 'Shell-Cell' Containers and Images{}",
+            crate::debugger::Debugger::session_id()
+                .map(|id| format!(" | Debug Session: {id}"))
+                .unwrap_or_default()
+        ))
         .title_bottom("Ctrl-C or Ctrl-D: exit")
         .border_style(Style::new().light_magenta())
 }

--- a/src/cli/ls/app/ui.rs
+++ b/src/cli/ls/app/ui.rs
@@ -87,7 +87,12 @@ fn render_main_block(
 ) -> Rect {
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(format!("'Shell-Cell' {items_title}"))
+        .title(format!(
+            "'Shell-Cell' {items_title}{}",
+            crate::debugger::Debugger::session_id()
+                .map(|id| format!(" | Debug Session: {id}"))
+                .unwrap_or_default()
+        ))
         .title_bottom("h: Help")
         .border_style(Style::new().light_magenta());
     let inner = block.inner(area);

--- a/src/cli/run/app/preparing/ui.rs
+++ b/src/cli/run/app/preparing/ui.rs
@@ -19,7 +19,12 @@ impl Widget for &mut PreparingState {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::new().light_magenta())
-            .title("'Shell-Cell'")
+            .title(format!(
+                "'Shell-Cell'{}",
+                crate::debugger::Debugger::session_id()
+                    .map(|id| format!(" | Debug Session: {id}"))
+                    .unwrap_or_default()
+            ))
             .title_bottom("Ctrl-C or Ctrl-D: exit");
         let inner = block.inner(area);
         block.render(area, buf);

--- a/src/cli/run/app/running_pty/ui.rs
+++ b/src/cli/run/app/running_pty/ui.rs
@@ -17,10 +17,13 @@ impl Widget for &mut RunningPtyState {
             .borders(Borders::ALL)
             .border_style(Style::new().light_magenta())
             .title(format!(
-                "'Shell-Cell' | {} | {} | {}",
+                "'Shell-Cell' | {} | {} | {}{}",
                 self.container_id,
                 self.target_name,
-                self.location.display()
+                self.location.display(),
+                crate::debugger::Debugger::session_id()
+                    .map(|id| format!(" | Debug Session: {id}"))
+                    .unwrap_or_default()
             ))
             .title_bottom("Ctrl-H: Help");
         let inner = block.inner(area);

--- a/src/cli/run/app/ui.rs
+++ b/src/cli/run/app/ui.rs
@@ -24,7 +24,12 @@ impl Widget for &mut App {
                 let block = Block::default()
                     .borders(Borders::ALL)
                     .border_style(Style::new().light_magenta())
-                    .title("'Shell-Cell'");
+                    .title(format!(
+                        "'Shell-Cell'{}",
+                        crate::debugger::Debugger::session_id()
+                            .map(|id| format!(" | Debug Session: {id}"))
+                            .unwrap_or_default()
+                    ));
                 let inner = block.inner(area);
                 block.render(area, buf);
 

--- a/src/cli/stop/app/ui.rs
+++ b/src/cli/stop/app/ui.rs
@@ -167,7 +167,12 @@ fn render_stopping(
 fn main_block() -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
-        .title("Stopping Shell-Cell Containers")
+        .title(format!(
+            "Stopping Shell-Cell Containers{}",
+            crate::debugger::Debugger::session_id()
+                .map(|id| format!(" | Debug Session: {id}"))
+                .unwrap_or_default()
+        ))
         .title_bottom("Ctrl-C or Ctrl-D: exit")
         .border_style(Style::new().light_magenta())
 }

--- a/src/debugger/conf.rs
+++ b/src/debugger/conf.rs
@@ -1,0 +1,20 @@
+use config::Config;
+use serde::Deserialize;
+
+const ENV_VAR_PREFIX: &str = "SHELL_CELL_DEBUGGER";
+
+#[derive(Debug, Deserialize)]
+pub struct DebuggerConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl DebuggerConfig {
+    pub fn init() -> color_eyre::Result<Self> {
+        let res: DebuggerConfig = Config::builder()
+            .add_source(config::Environment::with_prefix(ENV_VAR_PREFIX).try_parsing(true))
+            .build()?
+            .try_deserialize()?;
+        Ok(res)
+    }
+}

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -11,6 +11,7 @@ static DEBUGGER: OnceLock<Debugger> = OnceLock::new();
 
 #[derive(Debug)]
 pub struct Debugger {
+    id: uuid::Uuid,
     pty_stdin_logs: Mutex<std::fs::File>,
     pty_stdout_logs: Mutex<std::fs::File>,
 }
@@ -27,13 +28,14 @@ impl Debugger {
                     Err(e)
                 }
             })?;
-            let date = chrono::Local::now().to_rfc3339();
+            let id = uuid::Uuid::now_v7();
             let pty_stdin_logs =
-                std::fs::File::create_new(debug_dir.join(format!("{date}_pty_stdin.logs")))?;
+                std::fs::File::create_new(debug_dir.join(format!("{id}_pty_stdin.logs")))?;
             let pty_stdout_logs =
-                std::fs::File::create_new(debug_dir.join(format!("{date}_pty_stdout.logs")))?;
+                std::fs::File::create_new(debug_dir.join(format!("{id}_pty_stdout.logs")))?;
 
             let debugger = Debugger {
+                id,
                 pty_stdin_logs: Mutex::new(pty_stdin_logs),
                 pty_stdout_logs: Mutex::new(pty_stdout_logs),
             };
@@ -42,6 +44,10 @@ impl Debugger {
                 .map_err(|_| color_eyre::eyre::eyre!("Debugger already initialised"))?;
         }
         Ok(())
+    }
+
+    pub fn session_id() -> Option<uuid::Uuid> {
+        DEBUGGER.get().map(|dbg| dbg.id)
     }
 
     pub fn log_pty_stdin(bytes: &[u8]) -> color_eyre::Result<()> {

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -29,10 +29,12 @@ impl Debugger {
                 }
             })?;
             let id = uuid::Uuid::now_v7();
+            let session_dir = debug_dir.join(id.to_string());
+            std::fs::create_dir(&session_dir)?;
             let pty_stdin_logs =
-                std::fs::File::create_new(debug_dir.join(format!("{id}_pty_stdin.logs")))?;
+                std::fs::File::create_new(session_dir.join("pty_stdin.logs"))?;
             let pty_stdout_logs =
-                std::fs::File::create_new(debug_dir.join(format!("{id}_pty_stdout.logs")))?;
+                std::fs::File::create_new(session_dir.join("pty_stdout.logs"))?;
 
             let debugger = Debugger {
                 id,

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -31,10 +31,8 @@ impl Debugger {
             let id = uuid::Uuid::now_v7();
             let session_dir = debug_dir.join(id.to_string());
             std::fs::create_dir(&session_dir)?;
-            let pty_stdin_logs =
-                std::fs::File::create_new(session_dir.join("pty_stdin.logs"))?;
-            let pty_stdout_logs =
-                std::fs::File::create_new(session_dir.join("pty_stdout.logs"))?;
+            let pty_stdin_logs = std::fs::File::create_new(session_dir.join("pty_stdin.logs"))?;
+            let pty_stdout_logs = std::fs::File::create_new(session_dir.join("pty_stdout.logs"))?;
 
             let debugger = Debugger {
                 id,

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -1,0 +1,66 @@
+mod conf;
+
+use std::{
+    io::Write as _,
+    sync::{Mutex, OnceLock},
+};
+
+use self::conf::DebuggerConfig;
+
+static DEBUGGER: OnceLock<Debugger> = OnceLock::new();
+
+#[derive(Debug)]
+pub struct Debugger {
+    pty_stdin_logs: Mutex<std::fs::File>,
+    pty_stdout_logs: Mutex<std::fs::File>,
+}
+
+impl Debugger {
+    pub fn init() -> color_eyre::Result<()> {
+        let config = DebuggerConfig::init()?;
+        if config.enabled {
+            let debug_dir = crate::scell_home_dir()?.join("debug");
+            std::fs::create_dir(&debug_dir).or_else(|e| {
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            })?;
+            let date = chrono::Local::now().to_rfc3339();
+            let pty_stdin_logs =
+                std::fs::File::create_new(debug_dir.join(format!("{date}_pty_stdin.logs")))?;
+            let pty_stdout_logs =
+                std::fs::File::create_new(debug_dir.join(format!("{date}_pty_stdout.logs")))?;
+
+            let debugger = Debugger {
+                pty_stdin_logs: Mutex::new(pty_stdin_logs),
+                pty_stdout_logs: Mutex::new(pty_stdout_logs),
+            };
+            DEBUGGER
+                .set(debugger)
+                .map_err(|_| color_eyre::eyre::eyre!("Debugger already initialised"))?;
+        }
+        Ok(())
+    }
+
+    pub fn log_pty_stdin(bytes: &[u8]) -> color_eyre::Result<()> {
+        if let Some(dbg) = DEBUGGER.get() {
+            dbg.pty_stdin_logs
+                .lock()
+                .map_err(|e| color_eyre::eyre::eyre!("{e}"))?
+                .write_all(bytes)?;
+        }
+        Ok(())
+    }
+
+    pub fn log_pty_stdout(bytes: &[u8]) -> color_eyre::Result<()> {
+        if let Some(dbg) = DEBUGGER.get() {
+            dbg.pty_stdout_logs
+                .lock()
+                .map_err(|e| color_eyre::eyre::eyre!("{e}"))?
+                .write_all(bytes)?;
+        }
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod buildkit;
 mod cli;
 mod crate_info;
+mod debugger;
 mod error;
 mod pty;
 mod scell;
@@ -13,7 +14,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use color_eyre::eyre::ContextCompat;
 
-use crate::cli::Cli;
+use crate::{cli::Cli, debugger::Debugger};
 
 fn scell_home_dir() -> color_eyre::Result<PathBuf> {
     const SCELL_HOME_DIR: &str = ".scell";
@@ -26,6 +27,7 @@ fn scell_home_dir() -> color_eyre::Result<PathBuf> {
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
+    Debugger::init()?;
     match Cli::try_parse() {
         Ok(cli) => {
             color_eyre::config::HookBuilder::default()

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -47,9 +47,11 @@ impl Pty {
                     LogOutput::StdOut { message }
                     | LogOutput::StdIn { message }
                     | LogOutput::Console { message } => {
+                        drop(crate::debugger::Debugger::log_pty_stdout(&message));
                         stdout_in.send(message)?;
                     },
                     LogOutput::StdErr { message } => {
+                        drop(crate::debugger::Debugger::log_pty_stdout(&message));
                         stderr_in.send(message)?;
                     },
                 }
@@ -60,6 +62,7 @@ impl Pty {
         let (stdin, stdin_out) = std::sync::mpsc::channel::<Bytes>();
         let _jh = tokio::spawn(async move {
             while let Ok(bytes) = stdin_out.recv() {
+                drop(crate::debugger::Debugger::log_pty_stdin(&bytes));
                 input.write_all(&bytes).await?;
                 input.flush().await?;
             }


### PR DESCRIPTION
# Description

Adds a `Debugger` module that logs PTY stdin/stdout to per-session files under `~/.scell/debug/` when enabled via the `SHELL_CELL_DEBUGGER_ENABLED=true` environment variable. Each debug session is identified by a UUID v7, which is also surfaced in the TUI title bar for easy correlation.

## Changes

- `src/debugger/mod.rs`: Global `Debugger` singleton (via `OnceLock`) initialized at startup; stores a UUID v7 session ID; logs are written to `~/.scell/debug/<session-uuid>/pty_stdin.logs` and `pty_stdout.logs`; exposes `log_pty_stdin`, `log_pty_stdout`, and `session_id` helpers
- `src/debugger/conf.rs`: Config struct deserialized from `SHELL_CELL_DEBUGGER_*` env vars using the `config` crate
- `src/pty/mod.rs`: Wires PTY stdin/stdout bytes through the debugger log calls
- `src/main.rs`: Calls `Debugger::init()` at startup
- `src/cli/*/app/ui.rs` (cleanup, ls, run, run/preparing, run/running_pty, stop): All TUI screens append `| Debug Session: <uuid>` to their title bar when the debugger is active