### PR TITLE
fix: Keep tx alive on UserError in PreparingState

### DIFF
--- a/src/cli/run/app/preparing/mod.rs
+++ b/src/cli/run/app/preparing/mod.rs
@@ -151,6 +151,9 @@ impl PreparingState {
                 Ok(res) => drop(tx.send(Ok(res))),
                 Err(e) if e.is::<UserError>() => {
                     drop(logs_tx.send((format!("{e}"), LogType::MainError)));
+                    // Keep tx alive so try_update() stays in PreparingState,
+                    // letting the user read the error before exiting with Ctrl-C/Ctrl-D.
+                    std::future::pending::<()>().await;
                 },
                 Err(e) => drop(tx.send(Err(e))),
             }


### PR DESCRIPTION
## Summary

- Fixes a crash where the `PreparingState` `rx` channel disconnected before a result was returned when a `UserError` occurred during preparation
- After logging a `UserError` to the TUI, the background task now calls `std::future::pending::<()>().await` to keep the `tx` sender alive, preventing the channel from disconnecting unexpectedly
- The TUI remains in `PreparingState` so the user can read the error and exit with Ctrl-C/Ctrl-D

Closes #136