### PR TITLE
fix: move orphan status to Status column in ls UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,18 +110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,15 +449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "config"
 version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,12 +552,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -847,27 +820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1890,12 +1842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,7 +2669,6 @@ dependencies = [
 name = "shell-cell"
 version = "1.6.4"
 dependencies = [
- "async-channel",
  "base64",
  "bollard",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ strip = true
 [profile.dist]
 inherits = "release"
 
-# Example of customizing binaries in Cargo.toml.
 [[bin]]
 name = "scell"
 path = "src/main.rs"
@@ -65,8 +64,6 @@ arithmetic_side_effects = "deny"
 
 
 [dependencies]
-
-async-channel = "2.5.0"
 bollard = "0.20.0"
 bytes = "1.11.0"
 chrono = "0.4.43"

--- a/src/cli/ls/app/ls/ui.rs
+++ b/src/cli/ls/app/ls/ui.rs
@@ -24,11 +24,7 @@ impl Widget for &LsState<SCellContainerInfo> {
 
         let rows = self.items.iter().map(|c| {
             let cells = vec![
-                Cell::from(if c.orphan {
-                    format!("{} (orphan)", c.id)
-                } else {
-                    c.id.to_string()
-                }),
+                Cell::from(c.id.to_string()),
                 Cell::from(
                     c.target
                         .as_ref()
@@ -43,7 +39,11 @@ impl Widget for &LsState<SCellContainerInfo> {
                     || "<empty>".to_string(),
                     |dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, false),
                 )),
-                Cell::from(c.status.to_string()),
+                Cell::from(if c.orphan {
+                    format!("{} (orphan)", c.status)
+                } else {
+                    c.status.to_string()
+                }),
             ];
             Row::new(cells).height(1)
         });
@@ -77,7 +77,7 @@ impl Widget for &LsState<SCellImageInfo> {
     ) where
         Self: Sized,
     {
-        let header_cells = ["ID", "Target", "Blueprint Location", "Created At"]
+        let header_cells = ["ID", "Target", "Blueprint Location", "Created At", "Status"]
             .iter()
             .map(|h| Cell::from(*h).style(Style::default().fg(Color::Cyan)));
         let header = Row::new(header_cells)
@@ -86,11 +86,7 @@ impl Widget for &LsState<SCellImageInfo> {
 
         let rows = self.items.iter().map(|c| {
             let cells = vec![
-                Cell::from(if c.orphan {
-                    format!("{} (orphan)", c.id)
-                } else {
-                    c.id.to_string()
-                }),
+                Cell::from(c.id.to_string()),
                 Cell::from(
                     c.target
                         .as_ref()
@@ -105,6 +101,7 @@ impl Widget for &LsState<SCellImageInfo> {
                     || "<empty>".to_string(),
                     |dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, false),
                 )),
+                Cell::from(if c.orphan { "orphan" } else { "-" }),
             ];
             Row::new(cells).height(1)
         });
@@ -112,8 +109,9 @@ impl Widget for &LsState<SCellImageInfo> {
         let widths = [
             Constraint::Percentage(25),
             Constraint::Percentage(5),
-            Constraint::Percentage(50),
+            Constraint::Percentage(40),
             Constraint::Percentage(20),
+            Constraint::Percentage(10),
         ];
 
         let table = Table::new(rows, widths)

--- a/src/cli/ls/app/removing/ui.rs
+++ b/src/cli/ls/app/removing/ui.rs
@@ -68,7 +68,7 @@ fn render_removing(
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            format!("Removing '{item}'",),
+            format!("Removing '{item}'"),
             Style::default().fg(Color::Gray),
         )),
     ];


### PR DESCRIPTION
# Description

Thanks for contributing to the project!
Please fill out this template to help us review your changes.

Move the orphan indicator out of the ID column and into a dedicated Status column for both containers and images in the `ls` command UI.

**Containers:** The ID cell now shows a clean ID. The existing Status column appends `(orphan)` to the container status when applicable (e.g. `running (orphan)`).

**Images:** The ID cell now shows a clean ID. A new Status column is added showing `orphan` or `-`.