### PR TITLE
fix: strip registry prefix from image name before orphan comparison

### DIFF
--- a/src/buildkit/image_info.rs
+++ b/src/buildkit/image_info.rs
@@ -38,6 +38,11 @@ impl TryFrom<(String, bollard::models::ImageSummary)> for SCellImageInfo {
         let Some((image_name, "latest")) = image_tag.split_once(':') else {
             color_eyre::eyre::bail!("'Shell-Cell' image tag must be '<scell_name>:latest'");
         };
+        // Podman qualifies names with a registry prefix (e.g. docker.io/library/scell-…);
+        // strip everything up to and including the last '/' so we get a bare image name.
+        let image_name = image_name
+            .rsplit_once('/')
+            .map_or(image_name, |(_, name)| name);
 
         let created_at = Some(
             DateTime::from_timestamp_secs(value.created)

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -56,7 +56,8 @@ impl Debugger {
     #[allow(dead_code)]
     pub fn log_debug(logs: impl std::fmt::Display) -> color_eyre::Result<()> {
         if let Some(dbg) = DEBUGGER.get() {
-            dbg.debug_logs
+            let _ = dbg
+                .debug_logs
                 .lock()
                 .map_err(|e| color_eyre::eyre::eyre!("{e}"))?
                 .write(format!("{logs}\n").as_bytes())?;

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -14,6 +14,7 @@ pub struct Debugger {
     id: uuid::Uuid,
     pty_stdin_logs: Mutex<std::fs::File>,
     pty_stdout_logs: Mutex<std::fs::File>,
+    debug_logs: Mutex<std::fs::File>,
 }
 
 impl Debugger {
@@ -33,11 +34,13 @@ impl Debugger {
             std::fs::create_dir(&session_dir)?;
             let pty_stdin_logs = std::fs::File::create_new(session_dir.join("pty_stdin.logs"))?;
             let pty_stdout_logs = std::fs::File::create_new(session_dir.join("pty_stdout.logs"))?;
+            let debug_logs = std::fs::File::create_new(session_dir.join("debug.logs"))?;
 
             let debugger = Debugger {
                 id,
                 pty_stdin_logs: Mutex::new(pty_stdin_logs),
                 pty_stdout_logs: Mutex::new(pty_stdout_logs),
+                debug_logs: Mutex::new(debug_logs),
             };
             DEBUGGER
                 .set(debugger)
@@ -48,6 +51,17 @@ impl Debugger {
 
     pub fn session_id() -> Option<uuid::Uuid> {
         DEBUGGER.get().map(|dbg| dbg.id)
+    }
+
+    #[allow(dead_code)]
+    pub fn log_debug(logs: impl std::fmt::Display) -> color_eyre::Result<()> {
+        if let Some(dbg) = DEBUGGER.get() {
+            dbg.debug_logs
+                .lock()
+                .map_err(|e| color_eyre::eyre::eyre!("{e}"))?
+                .write(format!("{logs}\n").as_bytes())?;
+        }
+        Ok(())
     }
 
     pub fn log_pty_stdin(bytes: &[u8]) -> color_eyre::Result<()> {


### PR DESCRIPTION
## Summary

- Podman qualifies image names with a registry prefix (e.g. `docker.io/library/scell-97d4fda45a1bec50:latest`) while Docker uses the bare name (`scell-97d4fda45a1bec50:latest`)
- This caused the orphan check (`image_id != id`) to always return `true` on Podman, marking every image as orphaned
- Fix: strip everything up to and including the last `/` from the image name before parsing it as `SCellId`, making the comparison work correctly on both runtimes