### PR TITLE
feat(cli): add headless mode for non-TTY environments

### DIFF
--- a/src/cli/cleanup/headless.rs
+++ b/src/cli/cleanup/headless.rs
@@ -1,0 +1,63 @@
+//! Headless implementation of `scell cleanup`: removes orphan (or all when
+//! `--all`) Shell-Cell containers and images, reporting outcomes on
+//! stdout/stderr.
+
+use crate::buildkit::{
+    BuildKitD, container_info::SCellContainerInfo, image_info::SCellImageInfo,
+};
+
+pub async fn cleanup(
+    buildkit: &BuildKitD,
+    all: bool,
+) -> color_eyre::Result<()> {
+    let containers = buildkit.list_containers().await?;
+    let images = buildkit.list_images().await?;
+
+    let containers: Vec<_> = if all {
+        containers
+    } else {
+        containers.into_iter().filter(|c| c.orphan).collect()
+    };
+    let images: Vec<_> = if all {
+        images
+    } else {
+        images.into_iter().filter(|i| i.orphan).collect()
+    };
+
+    if containers.is_empty() && images.is_empty() {
+        println!("Nothing to clean up");
+        return Ok(());
+    }
+
+    let mut failed: usize = 0;
+    for c in &containers {
+        let name = SCellContainerInfo::container_name(&c.id, c.service_name.as_ref());
+        match buildkit.cleanup_container(c).await {
+            Ok(()) => println!("removed container {name}"),
+            Err(e) => {
+                eprintln!("error: failed to remove container {name}: {e}");
+                failed = failed.saturating_add(1);
+            },
+        }
+    }
+    for i in &images {
+        let name = SCellImageInfo::image_name(&i.id);
+        match buildkit.cleanup_image(i).await {
+            Ok(()) => println!("removed image {name}"),
+            Err(e) => {
+                eprintln!("error: failed to remove image {name}: {e}");
+                failed = failed.saturating_add(1);
+            },
+        }
+    }
+    println!(
+        "removed {} container(s), {} image(s), {} failure(s)",
+        containers.len(),
+        images.len(),
+        failed
+    );
+    if failed > 0 {
+        color_eyre::eyre::bail!("{failed} cleanup operation(s) failed");
+    }
+    Ok(())
+}

--- a/src/cli/cleanup/mod.rs
+++ b/src/cli/cleanup/mod.rs
@@ -1,10 +1,17 @@
 mod app;
+mod headless;
 
 use self::app::App;
 use crate::{buildkit::BuildKitD, cli::terminal::Terminal};
 
-pub async fn cleanup(all: bool) -> color_eyre::Result<()> {
+pub async fn cleanup(
+    all: bool,
+    headless: bool,
+) -> color_eyre::Result<()> {
     let buildkit = BuildKitD::start().await?;
+    if headless {
+        return headless::cleanup(&buildkit, all).await;
+    }
     let mut terminal = Terminal::new()?;
     let res = App::run(&buildkit, all, &mut terminal);
     ratatui::try_restore()?;

--- a/src/cli/ls/headless.rs
+++ b/src/cli/ls/headless.rs
@@ -1,0 +1,65 @@
+//! Headless implementation of `scell ls`: prints a plain-text table of
+//! Shell-Cell containers to stdout.
+
+use std::fmt::Write as _;
+
+use crate::buildkit::{BuildKitD, container_info::SCellContainerInfo};
+
+pub async fn ls(buildkit: &BuildKitD) -> color_eyre::Result<()> {
+    let containers = buildkit.list_containers().await?;
+    if containers.is_empty() {
+        println!("No Shell-Cell containers");
+        return Ok(());
+    }
+
+    let rows: Vec<[String; 5]> = containers
+        .iter()
+        .map(|c| {
+            [
+                SCellContainerInfo::container_name(&c.id, c.service_name.as_ref()),
+                c.status.to_string(),
+                c.target
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+                c.location
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default(),
+                if c.orphan { "orphan" } else { "" }.to_string(),
+            ]
+        })
+        .collect();
+
+    let headers = ["NAME", "STATUS", "TARGET", "LOCATION", "FLAGS"];
+    let mut widths: [usize; 5] = headers.map(str::len);
+    for row in &rows {
+        for (i, cell) in row.iter().enumerate() {
+            if let Some(w) = widths.get_mut(i)
+                && cell.len() > *w
+            {
+                *w = cell.len();
+            }
+        }
+    }
+
+    let print_row = |cells: &[String; 5]| {
+        let mut line = String::new();
+        for (i, cell) in cells.iter().enumerate() {
+            let pad = widths.get(i).copied().unwrap_or(0);
+            if i > 0 {
+                line.push_str("  ");
+            }
+            // Padding write to in-memory String can't fail.
+            let _ = write!(line, "{cell:<pad$}");
+        }
+        println!("{}", line.trim_end());
+    };
+
+    let header_row: [String; 5] = headers.map(String::from);
+    print_row(&header_row);
+    for row in &rows {
+        print_row(row);
+    }
+    Ok(())
+}

--- a/src/cli/ls/mod.rs
+++ b/src/cli/ls/mod.rs
@@ -1,12 +1,16 @@
 mod app;
+mod headless;
 
 use crate::{
     buildkit::BuildKitD,
     cli::{ls::app::App, terminal::Terminal},
 };
 
-pub async fn ls() -> color_eyre::Result<()> {
+pub async fn ls(headless: bool) -> color_eyre::Result<()> {
     let buildkit = BuildKitD::start().await?;
+    if headless {
+        return headless::ls(&buildkit).await;
+    }
     let mut terminal = Terminal::new()?;
     let res = App::run(&buildkit, &mut terminal);
     ratatui::try_restore()?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ mod run;
 mod stop;
 mod terminal;
 
-use std::{path::PathBuf, time::Duration};
+use std::{io::IsTerminal, path::PathBuf, time::Duration};
 
 use clap::{Parser, Subcommand};
 use color_eyre::Section;
@@ -36,6 +36,11 @@ pub struct Cli {
     /// Suppress Docker build logs
     #[clap(short, long)]
     quiet: bool,
+
+    /// Force headless (non-TUI) mode. Auto-enabled when stdout is not a TTY.
+    /// Implies `--detach` for `run` (no shell session attached).
+    #[clap(long)]
+    headless: bool,
 
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -83,12 +88,20 @@ impl Cli {
     }
 
     pub async fn exec_inner(self) -> color_eyre::Result<()> {
+        // Auto-headless when stdout is not a TTY (CI, scripts, agents,
+        // `nohup`, etc.), or when `--headless` is explicitly requested.
+        let headless = self.headless || !std::io::stdout().is_terminal();
         match self.command {
-            None => run::run(self.scell_path, self.target, self.detach, self.quiet).await?,
+            None => {
+                // Attaching an interactive shell requires a TTY; force detach
+                // in headless mode.
+                let detach = self.detach || headless;
+                run::run(self.scell_path, self.target, detach, self.quiet).await?;
+            },
             Some(Commands::Init { path }) => init::init(path)?,
-            Some(Commands::Ls) => ls::ls().await?,
-            Some(Commands::Stop) => stop::stop().await?,
-            Some(Commands::Cleanup { all }) => cleanup::cleanup(all).await?,
+            Some(Commands::Ls) => ls::ls(headless).await?,
+            Some(Commands::Stop) => stop::stop(headless).await?,
+            Some(Commands::Cleanup { all }) => cleanup::cleanup(all, headless).await?,
         }
         Ok(())
     }

--- a/src/cli/run/app/mod.rs
+++ b/src/cli/run/app/mod.rs
@@ -3,7 +3,7 @@ mod preparing;
 mod running_pty;
 mod ui;
 
-use std::path::Path;
+use std::{path::Path, sync::mpsc::RecvTimeoutError};
 
 use ratatui::crossterm::event::{self, Event, KeyEventKind};
 
@@ -12,7 +12,9 @@ use crate::{
     cli::{
         MIN_FPS,
         run::app::{
-            help_window::HelpWindowState, preparing::PreparingState, running_pty::RunningPtyState,
+            help_window::HelpWindowState,
+            preparing::{LogType, PreparingState},
+            running_pty::RunningPtyState,
         },
         terminal::Terminal,
     },
@@ -65,6 +67,47 @@ impl App {
 
             app = app.handle_key_event()?;
         }
+    }
+
+    /// Headless variant for `--detach`. No TTY/Terminal required:
+    /// runs the same preparation pipeline as the TUI but streams logs to
+    /// stderr and exits when the container is started.
+    #[allow(clippy::unused_async)] // kept async to match callsite/expectations
+    pub async fn run_headless<P>(
+        buildkit: &BuildKitD,
+        scell_path: P,
+        entry_target: Option<TargetName>,
+        quiet: bool,
+    ) -> color_eyre::Result<()>
+    where
+        P: AsRef<Path> + Send + 'static,
+    {
+        let app = PreparingState::prepare(buildkit.clone(), scell_path, entry_target, true, quiet);
+        let App::Preparing(state) = app else {
+            // PreparingState::prepare always returns App::Preparing
+            return Ok(());
+        };
+
+        loop {
+            match state.logs_rx.recv_timeout(MIN_FPS) {
+                Ok((msg, log_type)) => match log_type {
+                    LogType::MainError => eprintln!("error: {msg}"),
+                    _ => eprintln!("{msg}"),
+                },
+                Err(RecvTimeoutError::Timeout) => {},
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+
+            match state.rx.try_recv() {
+                Ok(res) => {
+                    res?;
+                    return Ok(());
+                },
+                Err(std::sync::mpsc::TryRecvError::Empty) => {},
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+            }
+        }
+        Ok(())
     }
 
     fn handle_key_event(mut self) -> color_eyre::Result<Self> {

--- a/src/cli/run/app/preparing/mod.rs
+++ b/src/cli/run/app/preparing/mod.rs
@@ -151,9 +151,15 @@ impl PreparingState {
                 Ok(res) => drop(tx.send(Ok(res))),
                 Err(e) if e.is::<UserError>() => {
                     drop(logs_tx.send((format!("{e}"), LogType::MainError)));
-                    // Keep tx alive so try_update() stays in PreparingState,
-                    // letting the user read the error before exiting with Ctrl-C/Ctrl-D.
-                    std::future::pending::<()>().await;
+                    if detach {
+                        // Headless: surface error and let the runner exit.
+                        drop(tx.send(Err(e)));
+                    } else {
+                        // TUI: keep tx alive so try_update() stays in
+                        // PreparingState, letting the user read the error
+                        // before exiting with Ctrl-C/Ctrl-D.
+                        std::future::pending::<()>().await;
+                    }
                 },
                 Err(e) => drop(tx.send(Err(e))),
             }

--- a/src/cli/run/app/preparing/ui.rs
+++ b/src/cli/run/app/preparing/ui.rs
@@ -42,7 +42,9 @@ impl Widget for &mut PreparingState {
                         // Adding some extra identation, so the text would always fits, even
                         // while adding some extra prefixes/suffixes etc. for different
                         // `LogType`s
-                        let area_width = area_width.saturating_sub(5);
+                        // `chunks(0)` panics in itertools; clamp to 1 so a
+                        // tiny render area can't crash the UI.
+                        let area_width = area_width.saturating_sub(5).max(1);
 
                         line.chars()
                             .chunks(area_width)

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -15,6 +15,11 @@ pub async fn run<P: AsRef<Path> + Send + 'static>(
     quiet: bool,
 ) -> color_eyre::Result<()> {
     let buildkit = BuildKitD::start().await?;
+    if detach {
+        // Headless path: no TTY/raw-mode/Terminal needed when we don't
+        // attach a shell session. Drains build logs to stderr instead.
+        return App::run_headless(&buildkit, scell_path, target, quiet).await;
+    }
     let mut terminal = Terminal::new()?;
     let res = App::run(&buildkit, scell_path, target, detach, quiet, &mut terminal).await;
     ratatui::try_restore()?;

--- a/src/cli/stop/headless.rs
+++ b/src/cli/stop/headless.rs
@@ -1,0 +1,41 @@
+//! Headless implementation of `scell stop`: stops all running Shell-Cell
+//! containers and reports outcomes line by line on stdout/stderr.
+
+use crate::buildkit::{
+    BuildKitD,
+    container_info::{SCellContainerInfo, Status},
+};
+
+pub async fn stop(buildkit: &BuildKitD) -> color_eyre::Result<()> {
+    let containers = buildkit.list_containers().await?;
+    let running: Vec<_> = containers
+        .into_iter()
+        .filter(|c| c.status == Status::Running)
+        .collect();
+
+    if running.is_empty() {
+        println!("No running Shell-Cell containers");
+        return Ok(());
+    }
+
+    let mut stopped: usize = 0;
+    let mut failed: usize = 0;
+    for c in &running {
+        let name = SCellContainerInfo::container_name(&c.id, c.service_name.as_ref());
+        match buildkit.stop_container(c).await {
+            Ok(()) => {
+                println!("stopped {name}");
+                stopped = stopped.saturating_add(1);
+            },
+            Err(e) => {
+                eprintln!("error: failed to stop {name}: {e}");
+                failed = failed.saturating_add(1);
+            },
+        }
+    }
+    println!("stopped {stopped}, failed {failed}");
+    if failed > 0 {
+        color_eyre::eyre::bail!("{failed} container(s) failed to stop");
+    }
+    Ok(())
+}

--- a/src/cli/stop/mod.rs
+++ b/src/cli/stop/mod.rs
@@ -1,12 +1,16 @@
 mod app;
+mod headless;
 
 use crate::{
     buildkit::BuildKitD,
     cli::{stop::app::App, terminal::Terminal},
 };
 
-pub async fn stop() -> color_eyre::Result<()> {
+pub async fn stop(headless: bool) -> color_eyre::Result<()> {
     let buildkit = BuildKitD::start().await?;
+    if headless {
+        return headless::stop(&buildkit).await;
+    }
     let mut terminal = Terminal::new()?;
     let res = App::run(&buildkit, &mut terminal);
     ratatui::try_restore()?;


### PR DESCRIPTION
## Problem

`scell -d` (and `scell ls` / `stop` / `cleanup`) crash with `No such device or address (os error 6)` when stdout is not a TTY:

```
$ scell -d /path/to/project
Error:
   0: No such device or address (os error 6)
```

This makes shell-cell unusable from CI, scripts, agents (e.g. Claude Code), `nohup`, container init systems — any environment without an interactive terminal. The `--detach` flag specifically advertises a non-interactive use case, yet was the most prominently broken path.

## Why `-d` didn't work

`src/cli/run/mod.rs` calls `Terminal::new()` **before** the detach branch:

```rust
pub async fn run(...) -> Result<()> {
    let buildkit = BuildKitD::start().await?;
    let mut terminal = Terminal::new()?;   // ← always runs, even when detached
    let res = App::run(&buildkit, ..., detach, ..., &mut terminal).await;
    ratatui::try_restore()?;
    res
}
```

`Terminal::new()` enables crossterm raw mode (`tcsetattr` + `ioctl` on stdout fd). The kernel returns `ENXIO` when the fd isn't a real TTY, so `Terminal::new()` aborts before any detach logic runs.

The same pattern exists in `ls/mod.rs`, `stop/mod.rs`, and `cleanup/mod.rs` — all unconditionally initialise the TUI even though their work (listing/stopping/removing containers) is naturally plain text. So 4 of 5 subcommands were headless-unusable; only `init` worked (it never touched `Terminal`).

A latent panic in `src/cli/run/app/preparing/ui.rs:45` compounded the problem under `script`-wrapped PTYs:

```rust
let area_width = area_width.saturating_sub(5);
line.chars().chunks(area_width)   // itertools panics on chunks(0)
```

When the render area is ≤5 cols (or 0, which can happen when terminal width can't be detected), the app panics with `assertion failed: size != 0`.

## Why it works now

1. **Auto-detect non-TTY** via `std::io::IsTerminal` on stdout in `Cli::exec_inner`. Non-TTY stdout implicitly enables `--headless`; `--headless` implicitly enables `--detach` for `run` (an interactive shell session still needs a TTY).
2. **Explicit `--headless` flag** for forcing headless mode even on a TTY (useful for scripted invocations).
3. **`run::run` skips `Terminal::new()` when detached**, dispatching to a new `App::run_headless()` that **reuses the existing `PreparingState`** — same tokio task, same channels — but drains build logs to stderr instead of rendering them. Business logic is shared with the TUI path; only the sink differs.
4. **`PreparingState::prepare` propagates `UserError` through `tx` in detach mode** instead of hanging on `future::pending()` forever. TUI behaviour preserved when interactive.
5. **`ls` / `stop` / `cleanup`** gain `headless.rs` siblings that call the same `BuildKitD::{list,stop,cleanup}_*` methods used by the TUI state machines and print plain text:
   - `ls`: tab-aligned table (`NAME STATUS TARGET LOCATION FLAGS`).
   - `stop`: `stopped <name>` per success / `error: failed to stop <name>: <err>` per failure / `stopped N, failed M` summary, non-zero exit on any failure.
   - `cleanup`: `removed container/image <name>` per item / same error+summary format / non-zero exit on any failure.
6. **`chunks(area_width.saturating_sub(5).max(1))`** clamps the preparing UI splitter so the latent `size != 0` panic can't fire on tiny terminals.

Routing summary:

| stdout | flag | `run` behaviour |
|---|---|---|
| TTY | none | TUI + attach interactive shell (unchanged) |
| TTY | `-d` | TUI + detach (unchanged) |
| TTY | `--headless` | headless, implicit detach |
| non-TTY | any | auto-headless, implicit detach |

| subcommand | TTY | non-TTY |
|---|---|---|
| `init` | plain text (unchanged) | plain text (unchanged) |
| `ls` | TUI | plain-text table |
| `stop` | TUI | line-per-action summary |
| `cleanup` | TUI | line-per-action summary |
| `run` | TUI | auto-headless build, container stays up |

## Verified

- `cargo build --release` — clean
- `cargo clippy --all-targets --release` — clean (strict pedantic config kept)
- `cargo test -- --test-threads 1` — 107 / 107 passed
- Manual smoke from a non-TTY shell:
  ```
  $ scell <path>           # auto-detach, builds, container hangs
  $ scell ls               # plain table
  $ scell stop             # stopped <name> + summary
  $ scell cleanup --all    # removed container/image lines + summary
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)