### PR TITLE
fix: set default timeout of 30 seconds in e2e expect helper

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,9 +1,10 @@
 name: E2E Nightly
 
 on:
-  schedule:
-    # Runs every day at 00:00
-    - cron: '0 0 * * *'
+  pull_request:
+  # schedule:
+  #   # Runs every day at 00:00
+  #   - cron: '0 0 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,10 +1,10 @@
 name: E2E Nightly
 
 on:
-  pull_request:
-  # schedule:
-  #   # Runs every day at 00:00
-  #   - cron: '0 0 * * *'
+  # pull_request:
+  schedule:
+    # Runs every day at 00:00
+    - cron: '0 0 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/e2e-tests/tests/conftest.py
+++ b/e2e-tests/tests/conftest.py
@@ -1,0 +1,13 @@
+import subprocess
+
+import pytest
+
+from scell import get_scell_bin
+
+
+@pytest.fixture(autouse=True)
+def stop_containers():
+    yield
+    scell_bin = get_scell_bin()
+    result = subprocess.run([scell_bin, "stop"], check=False)
+    assert result.returncode == 0, f"'scell stop' failed with exit code {result.returncode}"

--- a/e2e-tests/tests/scell.py
+++ b/e2e-tests/tests/scell.py
@@ -18,10 +18,8 @@ class SCell:
     def exitstatus(self) -> int | None:
         return self._process.exitstatus
 
-    def expect(self, pattern: Any, timeout: int | None = None) -> int:
-        if timeout is not None:
-            return self._process.expect(pattern, timeout=timeout)
-        return self._process.expect(pattern)
+    def expect(self, pattern: Any, timeout: int = 30) -> int:
+        return self._process.expect(pattern, timeout=timeout)
 
     def send(self, s: str) -> int:
         return self._process.send(f"{s}\r")

--- a/e2e-tests/tests/scell.py
+++ b/e2e-tests/tests/scell.py
@@ -41,13 +41,6 @@ def assert_clean_exit(child: SCell) -> None:
     assert child.exitstatus == 0
 
 
-@pytest.fixture(autouse=True)
-def stop_containers():
-    yield
-    scell_bin = get_scell_bin()
-    result = subprocess.run([scell_bin, "stop"], check=False)
-    assert result.returncode == 0, f"'scell stop' failed with exit code {result.returncode}"
-
 
 @pytest.fixture(scope="session")
 def spawn_scell():

--- a/e2e-tests/tests/scell.py
+++ b/e2e-tests/tests/scell.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from typing import Any
 
 import pexpect
@@ -28,16 +29,29 @@ class SCell:
         self._process.close()
 
 
+def get_scell_bin() -> str:
+    scell_bin = os.environ.get("SCELL_BIN")
+    assert scell_bin, "Set the 'SCELL_BIN' env var with the path to the 'scell' binary on your machine"
+    return scell_bin
+
+
 def assert_clean_exit(child: SCell) -> None:
     child.expect(pexpect.EOF, timeout=1)
     child.close()
     assert child.exitstatus == 0
 
 
+@pytest.fixture(autouse=True)
+def stop_containers():
+    yield
+    scell_bin = get_scell_bin()
+    result = subprocess.run([scell_bin, "stop"], check=False)
+    assert result.returncode == 0, f"'scell stop' failed with exit code {result.returncode}"
+
+
 @pytest.fixture(scope="session")
 def spawn_scell():
-    scell_bin = os.environ.get("SCELL_BIN")
-    assert scell_bin, "Set the 'SCELL_BIN' env var with the path to the 'scell' binary on your machine"
+    scell_bin = get_scell_bin()
 
     def spawn_scell(args: list[str], timeout: int = 10) -> SCell:
         scell_process = pexpect.spawn(


### PR DESCRIPTION
# Description

Simplifies the `expect` helper in `e2e-tests/tests/scell.py` by replacing the conditional `timeout` branch with a default parameter value of 30 seconds.

## Related Issue(s) (Optional)

N/A