### PR TITLE
feat: run global session via `-g`/`--global` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "shell-cell"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "base64",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell-cell"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2024"
 description = "Shell-Cell. CLI app to spawn and manage containerized shell environments"
 repository = "https://github.com/Mr-Leshiy/shell-cell"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,13 +51,16 @@ If your configuration file is located elsewhere and you don’t want to change d
 scell ./path/to/the/blueprint/directory
 ```
 
-#### Global blueprint fallback
+#### Global session (`-g`, `--global`)
 
-If the target directory has no `scell.cue` of its own, **Shell-Cell** falls back to the global blueprint located at
-`~/.scell/scell.cue` (when one exists). This lets you keep a default environment that works from anywhere, without
-adding a blueprint to every directory. Create it with [`scell init --global`](#global-blueprint--g---global).
+Pass the `-g`, `--global` flag to start the session from the global blueprint located at
+`~/.scell/scell.cue`, ignoring any local `scell.cue`.
+```shell
+scell --global
+```
 
-A local `scell.cue` always takes precedence over the global one.
+This lets you keep a default environment that works from anywhere, without adding a blueprint to every directory.
+Create the global blueprint with [`scell init --global`](#global-blueprint--g---global).
 
 ### `init` — Create a Blueprint
 
@@ -79,8 +82,8 @@ Pass the `-g`, `--global` flag to create the blueprint in the global **Shell-Cel
 scell init --global
 ```
 
-This global blueprint acts as a fallback that is used by `run` whenever the current directory has no `scell.cue` of its own
-(see [Global blueprint fallback](#global-blueprint-fallback)).
+This global blueprint can be launched from anywhere by running `scell` with the `-g`, `--global` flag
+(see [Global session](#global-session--g---global)).
 
 ### `ls` — List Shell-Cell Containers
 

--- a/e2e-tests/tests/test_basic.py
+++ b/e2e-tests/tests/test_basic.py
@@ -3,6 +3,6 @@ from scell import assert_clean_exit, spawn_scell
 
 def test_scell_basic(spawn_scell) -> None:
     scell = spawn_scell(args=["--version"])
-    scell.expect("shell-cell 1.7.0")
+    scell.expect("shell-cell 1.7.1")
 
     assert_clean_exit(scell)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,6 +37,11 @@ pub struct Cli {
     #[clap(short, long)]
     quiet: bool,
 
+    /// Run the session from the global blueprint located in the Shell-Cell home directory
+    /// (`~/.scell`), ignoring any local `scell.cue`
+    #[clap(short, long)]
+    global: bool,
+
     #[clap(subcommand)]
     command: Option<Commands>,
 }
@@ -92,7 +97,16 @@ impl Cli {
 
     pub async fn exec_inner(self) -> color_eyre::Result<()> {
         match self.command {
-            None => run::run(self.scell_path, self.target, self.detach, self.quiet).await?,
+            None => {
+                run::run(
+                    self.scell_path,
+                    self.target,
+                    self.detach,
+                    self.quiet,
+                    self.global,
+                )
+                .await?
+            }
             Some(Commands::Init { path, global }) => init::init(path, global)?,
             Some(Commands::Ls) => ls::ls().await?,
             Some(Commands::Stop { silent }) => stop::stop(silent).await?,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,7 +105,7 @@ impl Cli {
                     self.quiet,
                     self.global,
                 )
-                .await?
+                .await?;
             },
             Some(Commands::Init { path, global }) => init::init(path, global)?,
             Some(Commands::Ls) => ls::ls().await?,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -106,7 +106,7 @@ impl Cli {
                     self.global,
                 )
                 .await?
-            }
+            },
             Some(Commands::Init { path, global }) => init::init(path, global)?,
             Some(Commands::Ls) => ls::ls().await?,
             Some(Commands::Stop { silent }) => stop::stop(silent).await?,

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -1,11 +1,11 @@
 mod app;
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::{
     buildkit::BuildKitD,
     cli::{run::app::App, terminal::Terminal},
-    scell::types::{SCELL_CUE_FILE_NAME, name::TargetName},
+    scell::types::name::TargetName,
     scell_home_dir,
 };
 
@@ -14,25 +14,18 @@ pub async fn run<P: AsRef<Path> + Send + 'static>(
     target: Option<TargetName>,
     detach: bool,
     quiet: bool,
+    global: bool,
 ) -> color_eyre::Result<()> {
-    let scell_path = resolve_scell_path(scell_path);
+    // When `--global` is set, the global blueprint in the Shell-Cell home directory is used,
+    // ignoring any local `scell.cue`. Otherwise the path provided by the user is used as is.
+    let scell_path = if global {
+        scell_home_dir()?
+    } else {
+        scell_path.as_ref().to_path_buf()
+    };
     let buildkit = BuildKitD::start().await?;
     let mut terminal = Terminal::new()?;
     let res = App::run(&buildkit, scell_path, target, detach, quiet, &mut terminal).await;
     ratatui::try_restore()?;
     res
-}
-
-/// Resolves the blueprint path provided by the user. When the path does not contain a
-/// `scell.cue` file, falls back to the global blueprint located at
-/// `scell_home_dir()/scell.cue` if it exists.
-fn resolve_scell_path<P: AsRef<Path>>(scell_path: P) -> PathBuf {
-    if let Ok(home_dir) = scell_home_dir()
-        && home_dir.join(SCELL_CUE_FILE_NAME).is_file()
-        && !scell_path.as_ref().join(SCELL_CUE_FILE_NAME).is_file()
-    {
-        home_dir
-    } else {
-        scell_path.as_ref().to_path_buf()
-    }
 }


### PR DESCRIPTION
## Summary

Replaces the implicit global-blueprint fallback with an explicit `-g`/`--global` flag on the `run` command.

- **Before:** `run` automatically fell back to the global blueprint (`~/.scell/scell.cue`) whenever the current directory had no `scell.cue` of its own.
- **Now:** the global blueprint is used **only** when `-g`/`--global` is passed, ignoring any local `scell.cue`. Without the flag, the provided path is used as-is — no implicit defaulting.