### PR TITLE
feat: reusable HelpWindow widget with proper centered alignment

### DIFF
--- a/src/cli/help_window_widget.rs
+++ b/src/cli/help_window_widget.rs
@@ -205,7 +205,7 @@ impl Widget for HelpWindow<'_> {
                             .add_modifier(Modifier::BOLD),
                     )
                     .centered()
-                    .render(*row, buf)
+                    .render(*row, buf);
                 },
                 HelpEntry::Section(text) => {
                     Line::styled(
@@ -215,7 +215,7 @@ impl Widget for HelpWindow<'_> {
                             .add_modifier(Modifier::BOLD),
                     )
                     .centered()
-                    .render(*row, buf)
+                    .render(*row, buf);
                 },
                 HelpEntry::Shortcut {
                     key,

--- a/src/cli/help_window_widget.rs
+++ b/src/cli/help_window_widget.rs
@@ -1,0 +1,271 @@
+//! Reusable, centered "Keyboard Shortcuts" popup shared by the TUI apps.
+//!
+//! Callers only describe *what* the help window contains, as a slice of
+//! [`HelpEntry`]; the widget takes care of sizing the popup, centering it in
+//! the available area and aligning the key / description columns.
+
+use ratatui::{
+    layout::{Constraint, Flex, HorizontalAlignment, Layout, Rect},
+    prelude::Buffer,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Widget},
+};
+
+/// Horizontal gap between the key column and the description column.
+const COLUMN_GAP: u16 = 2;
+/// Free space kept between the help text and the window borders.
+const WINDOW_PADDING: u16 = 2;
+/// Space taken by the left and right borders.
+const BORDERS_WIDTH: u16 = 2;
+/// Space taken by the top and bottom borders.
+const BORDERS_HEIGHT: u16 = 2;
+
+/// A single line of a help window.
+pub enum HelpEntry {
+    /// Empty spacer line.
+    Blank,
+    /// Title of the whole window, centered.
+    Title(&'static str),
+    /// Header of a group of shortcuts, centered.
+    Section(&'static str),
+    /// A key binding and what it does.
+    Shortcut {
+        /// Key (or key combination) to press.
+        key: &'static str,
+        /// Color of the key, used to highlight destructive actions.
+        key_color: Color,
+        /// What the key does.
+        description: &'static str,
+    },
+    /// Remark attached to the shortcut above, aligned with the descriptions.
+    Note(&'static str),
+}
+
+impl HelpEntry {
+    /// Width of the key, for entries that have one.
+    fn key_width(&self) -> Option<u16> {
+        match self {
+            Self::Shortcut { key, .. } => Some(text_width(key)),
+            _ => None,
+        }
+    }
+
+    /// Width of the description column content, for entries that have one.
+    fn description_width(&self) -> Option<u16> {
+        match self {
+            Self::Shortcut { description, .. } => Some(text_width(description)),
+            Self::Note(text) => Some(text_width(text)),
+            _ => None,
+        }
+    }
+
+    /// Width of a standalone (centered) line, for entries that have one.
+    fn centered_width(&self) -> Option<u16> {
+        match self {
+            Self::Title(text) | Self::Section(text) => Some(text_width(text)),
+            _ => None,
+        }
+    }
+}
+
+/// Centered popup listing keyboard shortcuts.
+pub struct HelpWindow<'a> {
+    /// Lines of the window, in render order.
+    entries: &'a [HelpEntry],
+    /// Text of the top border.
+    title: &'a str,
+    /// Text of the bottom border, usually telling how to close the window.
+    footer: &'a str,
+}
+
+impl<'a> HelpWindow<'a> {
+    /// Creates a help window rendering the given entries.
+    pub const fn new(entries: &'a [HelpEntry]) -> Self {
+        Self {
+            entries,
+            title: "Help",
+            footer: "",
+        }
+    }
+
+    /// Overrides the text rendered on the top border.
+    #[expect(dead_code, reason = "part of the widget API")]
+    pub const fn title(
+        mut self,
+        title: &'a str,
+    ) -> Self {
+        self.title = title;
+        self
+    }
+
+    /// Sets the hint rendered on the bottom border.
+    pub const fn footer(
+        mut self,
+        footer: &'a str,
+    ) -> Self {
+        self.footer = footer;
+        self
+    }
+
+    /// Width of the key column, shared by every shortcut row.
+    fn key_width(&self) -> u16 {
+        self.entries
+            .iter()
+            .filter_map(HelpEntry::key_width)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Width of the description column, shared by every shortcut row.
+    fn description_width(&self) -> u16 {
+        self.entries
+            .iter()
+            .filter_map(HelpEntry::description_width)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Size of the popup, borders included.
+    fn window_size(&self) -> (u16, u16) {
+        // Widest line that is centered on its own, borders included.
+        let centered_width = self
+            .entries
+            .iter()
+            .filter_map(HelpEntry::centered_width)
+            .chain([
+                text_width(self.title).saturating_add(BORDERS_WIDTH),
+                text_width(self.footer).saturating_add(BORDERS_WIDTH),
+            ])
+            .max()
+            .unwrap_or(0);
+
+        let content_width = self
+            .key_width()
+            .saturating_add(COLUMN_GAP)
+            .saturating_add(self.description_width())
+            .max(centered_width);
+
+        let width = content_width
+            .saturating_add(WINDOW_PADDING.saturating_mul(2))
+            .saturating_add(BORDERS_WIDTH);
+        let height = u16::try_from(self.entries.len())
+            .unwrap_or(u16::MAX)
+            .saturating_add(BORDERS_HEIGHT);
+
+        (width, height)
+    }
+}
+
+impl Widget for HelpWindow<'_> {
+    fn render(
+        self,
+        area: Rect,
+        buf: &mut Buffer,
+    ) where
+        Self: Sized,
+    {
+        let key_width = self.key_width();
+        let description_width = self.description_width();
+        let (width, height) = self.window_size();
+
+        // Center the window itself inside the available area.
+        let [area] = Layout::horizontal([Constraint::Length(width)])
+            .flex(Flex::Center)
+            .areas(area);
+        let [window] = Layout::vertical([Constraint::Length(height)])
+            .flex(Flex::Center)
+            .areas(area);
+
+        Clear.render(window, buf);
+
+        let mut block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} ", self.title))
+            .title_alignment(HorizontalAlignment::Center)
+            .border_style(Style::default().fg(Color::Cyan));
+        if !self.footer.is_empty() {
+            block = block.title_bottom(format!(" {} ", self.footer));
+        }
+
+        let inner = block.inner(window);
+        block.render(window, buf);
+
+        // One row per entry.
+        let rows = Layout::vertical(vec![Constraint::Length(1); self.entries.len()]).split(inner);
+
+        for (entry, row) in self.entries.iter().zip(rows.iter()) {
+            match entry {
+                HelpEntry::Blank => {},
+                HelpEntry::Title(text) => {
+                    Line::styled(
+                        *text,
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .centered()
+                    .render(*row, buf)
+                },
+                HelpEntry::Section(text) => {
+                    Line::styled(
+                        *text,
+                        Style::default()
+                            .fg(Color::LightMagenta)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .centered()
+                    .render(*row, buf)
+                },
+                HelpEntry::Shortcut {
+                    key,
+                    key_color,
+                    description,
+                } => {
+                    let (key_area, description_area) = columns(*row, key_width, description_width);
+
+                    Line::styled(
+                        *key,
+                        Style::default().fg(*key_color).add_modifier(Modifier::BOLD),
+                    )
+                    .centered()
+                    .render(key_area, buf);
+
+                    Line::styled(*description, Style::default().fg(Color::White))
+                        .left_aligned()
+                        .render(description_area, buf);
+                },
+                HelpEntry::Note(text) => {
+                    let (_, description_area) = columns(*row, key_width, description_width);
+
+                    Line::styled(*text, Style::default().fg(Color::DarkGray))
+                        .left_aligned()
+                        .render(description_area, buf);
+                },
+            }
+        }
+    }
+}
+
+/// Splits a row into the key and the description columns, keeping the pair
+/// centered so that every row shares the same column edges.
+fn columns(
+    row: Rect,
+    key_width: u16,
+    description_width: u16,
+) -> (Rect, Rect) {
+    let [key_area, _, description_area] = Layout::horizontal([
+        Constraint::Length(key_width),
+        Constraint::Length(COLUMN_GAP),
+        Constraint::Length(description_width),
+    ])
+    .flex(Flex::Center)
+    .areas(row);
+
+    (key_area, description_area)
+}
+
+/// Rendered width of `text`, saturating at [`u16::MAX`].
+fn text_width(text: &str) -> u16 {
+    u16::try_from(Span::raw(text).width()).unwrap_or(u16::MAX)
+}

--- a/src/cli/ls/app/help_window/ui.rs
+++ b/src/cli/ls/app/help_window/ui.rs
@@ -1,17 +1,93 @@
-use ratatui::{
-    layout::{Constraint, HorizontalAlignment, Layout, Rect},
-    style::{Color, Modifier, Style},
-    text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
-};
+use ratatui::{layout::Rect, style::Color, widgets::Widget};
 
 use crate::{
     buildkit::{container_info::SCellContainerInfo, image_info::SCellImageInfo},
-    cli::ls::app::help_window::HelpWindowState,
+    cli::{
+        help_window_widget::{HelpEntry, HelpWindow},
+        ls::app::help_window::HelpWindowState,
+    },
 };
 
+/// Hint rendered on the bottom border.
+const FOOTER: &str = "h / Esc: close this window";
+
+const CONTAINER_HELP_ENTRIES: &[HelpEntry] = &[
+    HelpEntry::Title("Keyboard Shortcuts"),
+    HelpEntry::Blank,
+    HelpEntry::Section("Navigation"),
+    HelpEntry::Shortcut {
+        key: "↑ / ↓ / k / j",
+        key_color: Color::Yellow,
+        description: "Move selection",
+    },
+    HelpEntry::Blank,
+    HelpEntry::Section("Actions"),
+    HelpEntry::Shortcut {
+        key: "q",
+        key_color: Color::Yellow,
+        description: "Switch to the images view",
+    },
+    HelpEntry::Shortcut {
+        key: "i",
+        key_color: Color::Yellow,
+        description: "Inspect container definition",
+    },
+    HelpEntry::Shortcut {
+        key: "s",
+        key_color: Color::Yellow,
+        description: "Stop selected container",
+    },
+    HelpEntry::Shortcut {
+        key: "r",
+        key_color: Color::Yellow,
+        description: "Remove selected container",
+    },
+    HelpEntry::Blank,
+    HelpEntry::Section("General"),
+    HelpEntry::Shortcut {
+        key: "Ctrl-C / Ctrl-D",
+        key_color: Color::Red,
+        description: "Exit",
+    },
+];
+
+const IMAGE_HELP_ENTRIES: &[HelpEntry] = &[
+    HelpEntry::Title("Keyboard Shortcuts"),
+    HelpEntry::Blank,
+    HelpEntry::Section("Navigation"),
+    HelpEntry::Shortcut {
+        key: "↑ / ↓ / k / j",
+        key_color: Color::Yellow,
+        description: "Move selection",
+    },
+    HelpEntry::Blank,
+    HelpEntry::Section("Actions"),
+    HelpEntry::Shortcut {
+        key: "q",
+        key_color: Color::Yellow,
+        description: "Switch to the containers view",
+    },
+    HelpEntry::Shortcut {
+        key: "i",
+        key_color: Color::Yellow,
+        description: "Inspect image definition",
+    },
+    HelpEntry::Shortcut {
+        key: "r",
+        key_color: Color::Yellow,
+        description: "Remove selected image",
+    },
+    HelpEntry::Note("(can't remove image, which is in use)"),
+    HelpEntry::Blank,
+    HelpEntry::Section("General"),
+    HelpEntry::Shortcut {
+        key: "Ctrl-C / Ctrl-D",
+        key_color: Color::Red,
+        description: "Exit",
+    },
+];
+
 impl Widget for &HelpWindowState<SCellContainerInfo> {
-    #[allow(clippy::indexing_slicing, clippy::too_many_lines)]
     fn render(
         self,
         area: Rect,
@@ -21,128 +97,13 @@ impl Widget for &HelpWindowState<SCellContainerInfo> {
     {
         self.ls_state.render(area, buf);
 
-        let vertical = Layout::vertical([
-            Constraint::Percentage(15),
-            Constraint::Percentage(70),
-            Constraint::Percentage(15),
-        ])
-        .split(area);
-
-        let horizontal = Layout::horizontal([
-            Constraint::Percentage(25),
-            Constraint::Percentage(50),
-            Constraint::Percentage(25),
-        ])
-        .split(vertical[1]);
-
-        let help_text = vec![
-            Line::from(vec![Span::styled(
-                "Keyboard Shortcuts",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "Navigation",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "  ↑ / ↓ / k / j     ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Move selection", Style::default().fg(Color::White)),
-            ]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "Actions",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "  q                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Switch to the images view",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  i                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Inspect container definition",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  s                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Stop selected container", Style::default().fg(Color::White)),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  r                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Remove selected container",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "General",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "  Ctrl-C / Ctrl-D  ",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Exit", Style::default().fg(Color::White)),
-            ]),
-        ];
-
-        Widget::render(Clear, horizontal[1], buf);
-
-        let paragraph = Paragraph::new(help_text).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Help ")
-                .title_bottom("h / Esc: close this window")
-                .title_alignment(HorizontalAlignment::Center)
-                .border_style(Style::default().fg(Color::Cyan)),
-        );
-
-        paragraph.render(horizontal[1], buf);
+        HelpWindow::new(CONTAINER_HELP_ENTRIES)
+            .footer(FOOTER)
+            .render(area, buf);
     }
 }
 
 impl Widget for &HelpWindowState<SCellImageInfo> {
-    #[allow(clippy::indexing_slicing, clippy::too_many_lines)]
     fn render(
         self,
         area: Rect,
@@ -152,111 +113,8 @@ impl Widget for &HelpWindowState<SCellImageInfo> {
     {
         self.ls_state.render(area, buf);
 
-        let vertical = Layout::vertical([
-            Constraint::Percentage(15),
-            Constraint::Percentage(70),
-            Constraint::Percentage(15),
-        ])
-        .split(area);
-
-        let horizontal = Layout::horizontal([
-            Constraint::Percentage(25),
-            Constraint::Percentage(50),
-            Constraint::Percentage(25),
-        ])
-        .split(vertical[1]);
-
-        let help_text = vec![
-            Line::from(vec![Span::styled(
-                "Keyboard Shortcuts",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "Navigation",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "  ↑ / ↓ / k / j     ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Move selection", Style::default().fg(Color::White)),
-            ]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "Actions",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "  q                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Switch to the containers view",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  i                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Inspect image definition",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  r                 ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Remove selected image", Style::default().fg(Color::White)),
-            ]),
-            Line::from("                    (can't remove image, which is in use)"),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "General",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "  Ctrl-C / Ctrl-D  ",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Exit", Style::default().fg(Color::White)),
-            ]),
-        ];
-
-        Widget::render(Clear, horizontal[1], buf);
-
-        let paragraph = Paragraph::new(help_text).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Help ")
-                .title_bottom("h / Esc: close this window")
-                .title_alignment(HorizontalAlignment::Center)
-                .border_style(Style::default().fg(Color::Cyan)),
-        );
-
-        paragraph.render(horizontal[1], buf);
+        HelpWindow::new(IMAGE_HELP_ENTRIES)
+            .footer(FOOTER)
+            .render(area, buf);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! Command Line Interface implementation
 
 mod cleanup;
+mod help_window_widget;
 mod init;
 mod ls;
 mod run;

--- a/src/cli/run/app/help_window/ui.rs
+++ b/src/cli/run/app/help_window/ui.rs
@@ -1,14 +1,47 @@
-use ratatui::{
-    layout::{Constraint, HorizontalAlignment, Layout, Rect},
-    style::{Color, Modifier, Style},
-    text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
+use ratatui::{layout::Rect, style::Color, widgets::Widget};
+
+use crate::cli::{
+    help_window_widget::{HelpEntry, HelpWindow},
+    run::app::help_window::HelpWindowState,
 };
 
-use crate::cli::run::app::help_window::HelpWindowState;
+/// Hint rendered on the bottom border.
+const FOOTER: &str = "Ctrl-H / Esc: close this window";
+
+const HELP_ENTRIES: &[HelpEntry] = &[
+    HelpEntry::Title("Keyboard Shortcuts"),
+    HelpEntry::Blank,
+    HelpEntry::Section("Command mode (tmux-style)"),
+    HelpEntry::Shortcut {
+        key: "Ctrl-B",
+        key_color: Color::Yellow,
+        description: "Enter/Exit command mode",
+    },
+    HelpEntry::Shortcut {
+        key: "d",
+        key_color: Color::Red,
+        description: "Detach and close the session",
+    },
+    HelpEntry::Shortcut {
+        key: "↑ / ↓ / k / j",
+        key_color: Color::Yellow,
+        description: "Scroll the screen",
+    },
+    HelpEntry::Shortcut {
+        key: "Esc / Ctrl-B",
+        key_color: Color::Yellow,
+        description: "Exit command mode",
+    },
+    HelpEntry::Blank,
+    HelpEntry::Section("General"),
+    HelpEntry::Shortcut {
+        key: "Ctrl-H",
+        key_color: Color::Yellow,
+        description: "Open / close this help window",
+    },
+];
 
 impl Widget for &mut HelpWindowState {
-    #[allow(clippy::indexing_slicing, clippy::too_many_lines)]
     fn render(
         self,
         area: Rect,
@@ -18,106 +51,8 @@ impl Widget for &mut HelpWindowState {
     {
         self.0.render(area, buf);
 
-        let vertical = Layout::vertical([
-            Constraint::Percentage(15),
-            Constraint::Percentage(70),
-            Constraint::Percentage(15),
-        ])
-        .split(area);
-
-        let horizontal = Layout::horizontal([
-            Constraint::Percentage(25),
-            Constraint::Percentage(50),
-            Constraint::Percentage(25),
-        ])
-        .split(vertical[1]);
-
-        let help_text = vec![
-            Line::from(vec![Span::styled(
-                "Keyboard Shortcuts",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "Command mode (tmux-style)",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "        Ctrl-B        ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Enter command mode (shown in status bar)",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "          d           ",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Detach and close the session",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "    ↑ / ↓ / k / j      ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Scroll the screen", Style::default().fg(Color::White)),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "         Esc          ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("Exit command mode", Style::default().fg(Color::White)),
-            ]),
-            Line::from(""),
-            Line::from(vec![Span::styled(
-                "General",
-                Style::default()
-                    .fg(Color::LightMagenta)
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    "        Ctrl-H        ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    "Open / close this help window",
-                    Style::default().fg(Color::White),
-                ),
-            ]),
-        ];
-
-        Clear.render(horizontal[1], buf);
-
-        let paragraph = Paragraph::new(help_text).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Help ")
-                .title_bottom(" Ctrl-H / Esc: close this window")
-                .title_alignment(HorizontalAlignment::Center)
-                .border_style(Style::default().fg(Color::Cyan)),
-        );
-
-        paragraph.render(horizontal[1], buf);
+        HelpWindow::new(HELP_ENTRIES)
+            .footer(FOOTER)
+            .render(area, buf);
     }
 }

--- a/src/cli/run/app/running_pty/mod.rs
+++ b/src/cli/run/app/running_pty/mod.rs
@@ -159,7 +159,7 @@ impl RunningPtyState {
                 KeyCode::PageDown => self.scroll_down(PAGE_SCROLL_STEP),
                 KeyCode::Esc => self.mode = InputMode::Normal,
                 KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    self.mode = InputMode::Normal
+                    self.mode = InputMode::Normal;
                 },
                 _ => {},
             }

--- a/src/cli/run/app/running_pty/mod.rs
+++ b/src/cli/run/app/running_pty/mod.rs
@@ -158,6 +158,9 @@ impl RunningPtyState {
                 KeyCode::PageUp => self.scroll_up(PAGE_SCROLL_STEP),
                 KeyCode::PageDown => self.scroll_down(PAGE_SCROLL_STEP),
                 KeyCode::Esc => self.mode = InputMode::Normal,
+                KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.mode = InputMode::Normal
+                },
                 _ => {},
             }
         }

--- a/src/cli/run/app/running_pty/ui.rs
+++ b/src/cli/run/app/running_pty/ui.rs
@@ -17,15 +17,10 @@ impl Widget for &mut RunningPtyState {
             InputMode::Normal => {
                 (
                     Style::new().light_magenta(),
-                    "Ctrl-B: commands | Ctrl-H: help".to_owned(),
+                    "Ctrl-B: command mode | Ctrl-H: help".to_owned(),
                 )
             },
-            InputMode::Command => {
-                (
-                    Style::new().yellow(),
-                    "-- COMMAND -- d: detach | ↑/↓/k/j: scroll | Esc: exit".to_owned(),
-                )
-            },
+            InputMode::Command => (Style::new().yellow(), " COMMAND ".to_owned()),
         };
 
         let block = Block::default()


### PR DESCRIPTION
Replaces the hand-padded help windows with a reusable, self-sizing widget.

## Changes

- **New `src/cli/help_window_widget.rs`**: `HelpWindow` widget driven by a slice of `HelpEntry` (`Title`, `Section`, `Shortcut`, `Note`, `Blank`). It derives the popup size from its content and centers everything with ratatui layouts (`Flex::Center`), instead of hardcoded spaces inside `Span`s and percentage-based areas.
- Keys are centered in a shared column, descriptions share a common left edge, and the key/description pair is centered in the window.
- `run` and `ls` help windows are now just `const` entry lists; the two duplicated `ls` implementations collapse into data.
- `Ctrl-B` now also exits command mode, and the command-mode status line is shortened to `COMMAND` (the shortcuts live in the help window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)