### PR TITLE
fix: python e2e tests for tmux-style session exit

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,10 +1,10 @@
 name: E2E Nightly
 
 on:
-  pull_request:
-  # schedule:
-  #   # Runs every day at 00:00
-  #   - cron: '0 0 * * *'
+  # pull_request:
+  schedule:
+    # Runs every day at 00:00
+    - cron: '0 0 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,10 +1,10 @@
 name: E2E Nightly
 
 on:
-  # pull_request:
-  schedule:
-    # Runs every day at 00:00
-    - cron: '0 0 * * *'
+  pull_request:
+  # schedule:
+  #   # Runs every day at 00:00
+  #   - cron: '0 0 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/e2e-tests/tests/scell.py
+++ b/e2e-tests/tests/scell.py
@@ -8,6 +8,9 @@ import pytest
 SCELL_WINDOWN_WIDTH = 800
 SCELL_WINDOWN_HEIGHT = 600
 
+# 'tmux'-style command mode prefix
+CTRL_B = "\x02"
+
 
 class SCell:
     def __init__(self, process: pexpect.spawn) -> None:
@@ -23,7 +26,12 @@ class SCell:
         return self._process.expect(pattern, timeout=timeout)
 
     def send(self, s: str) -> int:
+        """Send a command line to the shell running inside the container."""
         return self._process.send(f"{s}\r")
+
+    def send_key(self, key: str) -> int:
+        """Send a raw keystroke to 'scell' itself, without a trailing newline."""
+        return self._process.send(key)
 
     def close(self) -> None:
         self._process.close()
@@ -39,6 +47,17 @@ def assert_clean_exit(child: SCell) -> None:
     child.expect(pexpect.EOF, timeout=1)
     child.close()
     assert child.exitstatus == 0
+
+
+def assert_scell_stop_session(scell: SCell) -> None:
+    # Closing a session is a 'tmux'-style two-step flow:
+    # 'Ctrl-B' enters the command mode, 'd' detaches and closes the session
+    scell.send_key(CTRL_B)
+    scell.send_key("d")
+    scell.expect("Finished 'Shell-Cell' session")
+    # scell shows "<Press any key to exit>" before quitting — send any key
+    scell.send_key(" ")
+    assert_clean_exit(scell)
 
 
 

--- a/e2e-tests/tests/test_init.py
+++ b/e2e-tests/tests/test_init.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import tempfile
 
-from scell import assert_clean_exit, spawn_scell
+from scell import assert_clean_exit, assert_scell_stop_session, spawn_scell
 
 
 def test_init(spawn_scell) -> None:
@@ -20,9 +20,4 @@ def test_init(spawn_scell) -> None:
         scell.expect("/my_project#")
 
         # Stop the session
-        # Send Ctrl-D to the shell to end the session
-        scell.send('\x04')
-        scell.expect("Finished 'Shell-Cell' session")
-        # scell shows "<Press any key to exit>" before quitting — send any key
-        scell.send(' ')
-        assert_clean_exit(scell)
+        assert_scell_stop_session(scell)

--- a/e2e-tests/tests/test_run.py
+++ b/e2e-tests/tests/test_run.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from scell import assert_clean_exit, spawn_scell, SCell
+from scell import assert_scell_stop_session, spawn_scell, SCell
 
 
 @dataclass
@@ -99,12 +99,3 @@ def assert_scell_prepare_session(scell: SCell):
     scell.expect("Starting 'Shell-Cell' session", timeout=120)
     scell.expect("root@")
     scell.expect("/app#")
-
-
-def assert_scell_stop_session(scell):
-    # Send Ctrl-D to the shell to end the session
-    scell.send('\x04')
-    scell.expect("Finished 'Shell-Cell' session")
-    # scell shows "<Press any key to exit>" before quitting — send any key
-    scell.send(' ')
-    assert_clean_exit(scell)


### PR DESCRIPTION
## Summary

The `tmux`-style command mode introduced in #154 changed how a session is closed, which broke the Python e2e tests still sending a bare `Ctrl-D`. This updates the tests to the new two-step detach flow and removes the duplication between the test modules.

- Add `send_key()` to the `SCell` helper for sending raw keystrokes to `scell` itself (no trailing newline), alongside the existing `send()` which writes a command line to the shell in the container.
- Add a shared `assert_scell_stop_session()` in `scell.py` that closes a session via `Ctrl-B` then `d`, waits for `Finished 'Shell-Cell' session`, and dismisses the `<Press any key to exit>` prompt.
- Use it from `test_init.py` and `test_run.py`, dropping the local copy that lived in `test_run.py`.

## Test plan

- [ ] e2e test job passes (`test_init`, `test_run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)